### PR TITLE
"Include children" doesn't work

### DIFF
--- a/src/UmbNav.Web/App_Plugins/UmbNav/js/umbnav.settings.controller.js
+++ b/src/UmbNav.Web/App_Plugins/UmbNav/js/umbnav.settings.controller.js
@@ -282,7 +282,7 @@
         $scope.model.target.hideLoggedOut = model ? true : false;
     }
     function toggleChildren(model, value) {
-        $scope.model.target.includeChildren = model ? true : false;
+        $scope.model.target.includeChildNodes = model ? true : false;
     }
     function toggleDisplayAsLabel(model, value) {
         $scope.model.target.displayAsLabel = model ? true : false;


### PR DESCRIPTION
In this file "$scope.model.target.includeChildren" is still used.
Changed to "$scope.model.target.includeChildNodes"