### PR TITLE
match view folder case, for case sensitive install

### DIFF
--- a/src/UmbNav.Web/App_Plugins/UmbNav/js/umbnav.controller.js
+++ b/src/UmbNav.Web/App_Plugins/UmbNav/js/umbnav.controller.js
@@ -108,7 +108,7 @@
 
         var settingsEditor = {
             title: "Settings",
-            view: "/App_Plugins/UmbNav/Views/settings.html",
+            view: "/App_Plugins/UmbNav/views/settings.html",
             size: "small",
             hideNoreferrer: dialogOptions.config.hideNoreferrer,
             hideNoopener: dialogOptions.config.hideNoopener,


### PR DESCRIPTION
views folder is lower case, so on case sensitive install (linux) it doesn't find it when you click add. 