### PR TITLE
Integrate w/Content Delivery API & maintain backwards compatibility

### DIFF
--- a/src/UmbNav.Core/Models/UmbNavItem.cs
+++ b/src/UmbNav.Core/Models/UmbNavItem.cs
@@ -9,6 +9,9 @@ namespace UmbNav.Core.Models
 {
     public class UmbNavItem
     {
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
         [JsonProperty("udi")]
         public GuidUdi Udi { get; set; }
 
@@ -62,9 +65,6 @@ namespace UmbNav.Core.Models
 
         [JsonProperty("hideLoggedOut")]
         internal bool HideLoggedOut { get; set; }
-
-        [JsonProperty("url")]
-        internal string Url { get; set; }
 
         [JsonProperty("includeChildNodes")]
         internal bool IncludeChildNodes { get; set; }

--- a/src/UmbNav.Core/ValueConverters/UmbNavValueConverter.cs
+++ b/src/UmbNav.Core/ValueConverters/UmbNavValueConverter.cs
@@ -1,18 +1,139 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using Serilog;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
 using UmbNav.Core.Interfaces;
 using UmbNav.Core.Models;
 using UmbNav.Core.PropertyEditors;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
-using Serilog;
 
 namespace UmbNav.Core.ValueConverters
 {
+#if NET8_0_OR_GREATER
+#nullable enable
+
+    using Umbraco.Cms.Core.DeliveryApi;
+    using Umbraco.Cms.Core.PropertyEditors.DeliveryApi;
+    using Umbraco.Cms.Core.PublishedCache;
+
+    public class CustomUmbNavValueConverter : PropertyValueConverterBase, IDeliveryApiPropertyValueConverter
+    {
+        private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;
+        private readonly IApiContentRouteBuilder _apiContentRouteBuilder;
+        private readonly ILogger _logger;
+        private readonly IUmbNavMenuBuilderService _umbNavMenuBuilderService;
+
+        public CustomUmbNavValueConverter(
+            IPublishedSnapshotAccessor publishedSnapshotAccessor,
+            IApiContentRouteBuilder apiContentRouteBuilder,
+            ILogger logger,
+            IUmbNavMenuBuilderService umbNavMenuBuilderService)
+        {
+            _publishedSnapshotAccessor = publishedSnapshotAccessor;
+            _apiContentRouteBuilder = apiContentRouteBuilder;
+            _logger = logger;
+            _umbNavMenuBuilderService = umbNavMenuBuilderService;
+        }
+
+        public override bool IsConverter(IPublishedPropertyType propertyType)
+            => propertyType.EditorAlias.Equals("AaronSadler.UmbNav");
+
+        public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
+            => typeof(IEnumerable<UmbNavItem>);
+
+        public PropertyCacheLevel GetDeliveryApiPropertyCacheLevel(IPublishedPropertyType propertyType)
+            => PropertyCacheLevel.Elements;
+
+        public PropertyCacheLevel GetDeliveryApiPropertyCacheLevelForExpansion(IPublishedPropertyType propertyType)
+            => PropertyCacheLevel.Snapshot;
+
+        public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType)
+            => typeof(IEnumerable<UmbNavItem>);
+
+        public override object? ConvertIntermediateToObject(
+            IPublishedElement owner,
+            IPublishedPropertyType propertyType,
+            PropertyCacheLevel referenceCacheLevel,
+            object? inter,
+            bool preview)
+        {
+            if (inter is null)
+            {
+                _logger.Warning("No intermediate value found for property {PropertyAlias}.", propertyType.Alias);
+                return Enumerable.Empty<UmbNavItem>();
+            }
+
+            try
+            {
+                var items = JsonConvert.DeserializeObject<IEnumerable<UmbNavItem>>(inter.ToString() ?? string.Empty);
+                if (items == null)
+                {
+                    _logger.Warning("Failed to deserialize UmbNav items for property {PropertyAlias}.", propertyType.Alias);
+                    return Enumerable.Empty<UmbNavItem>();
+                }
+
+                // Build the menu using the UmbNavMenuBuilderService
+                var configuration = propertyType.DataType.ConfigurationAs<UmbNavConfiguration>();
+                if (configuration != null)
+                {
+                    return _umbNavMenuBuilderService.BuildMenu(
+                        items,
+                        0,
+                        configuration.RemoveNaviHideItems,
+                        configuration.HideNoopener,
+                        configuration.HideNoreferrer,
+                        configuration.HideIncludeChildren,
+                        configuration.AllowMenuItemDescriptions);
+                }
+
+                return items;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Error converting UmbNav intermediate value for property {PropertyAlias}.", propertyType.Alias);
+                return Enumerable.Empty<UmbNavItem>();
+            }
+        }
+
+        public object? ConvertIntermediateToDeliveryApiObject(
+            IPublishedElement owner,
+            IPublishedPropertyType propertyType,
+            PropertyCacheLevel referenceCacheLevel,
+            object? inter,
+            bool preview,
+            bool expanding)
+        {
+            if (inter is null)
+            {
+                _logger.Warning("No intermediate value found for Delivery API conversion on property {PropertyAlias}.", propertyType.Alias);
+                return null;
+            }
+
+            try
+            {
+                var items = JsonConvert.DeserializeObject<IEnumerable<UmbNavItem>>(inter.ToString() ?? string.Empty);
+                if (items == null)
+                {
+                    _logger.Warning("Failed to deserialize UmbNav items for Delivery API on property {PropertyAlias}.", propertyType.Alias);
+                    return null;
+                }
+
+                return items;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Error converting UmbNav intermediate value for Delivery API on property {PropertyAlias}.", propertyType.Alias);
+                return null;
+            }
+        }
+    }
+    #else
     public class UmbNavValueConverter : PropertyValueConverterBase
     {
+
+
         private readonly IUmbNavMenuBuilderService _umbNavMenuBuilderService;
         private readonly ILogger _logger;
 
@@ -67,4 +188,5 @@ namespace UmbNav.Core.ValueConverters
             return Enumerable.Empty<UmbNavItem>();
         }
     }
+    #endif
 }


### PR DESCRIPTION
The UmbNav library is not currently compatible with the Umbraco Content Delivery API. To use the library with the content delivery API currently requires creating custom overrides within a given application. This PR implements the necessary code to allow for the UmbNav library to return useful content via the Umbraco Content Delivery API in versions of Umbraco that have Umbraco Content Delivery API available (v12 and up).

Without either custom overrides or this update to the library itself, when returning UmbNavItems via the Content Delivery API I received an alternating experience between a 500 error and content stuck in a recursive loop (the json ignore attribute on content in class UmbNavItem is not recognized by the content delivery api because the existing class, UmbNavValueConverter only extends PropertyValueConverterBase but does not also implement IDeliveryApiPropertyValueConverter).

See this issue for greater detail: https://github.com/AaronSadlerUK/Our.Umbraco.UmbNav/issues/96